### PR TITLE
chart/webhook: Add ClusterRole to create serviceaccounts/token

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.18.1+bm
+version: 1.18.2+bm
 appVersion: 1.18.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -46,6 +46,12 @@ rules:
     verbs:
       - "create"
       - "update"
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - "create"
 {{- if .Values.rbac.psp.enabled }}
   - apiGroups:
       - extensions


### PR DESCRIPTION
Add ClusterRole to create `serviceaccounts/token` since the `1.18.0` release include creation of serviceAccount tokens via apiserver.

Ref:
 - banzaicloud#1738
 - banzaicloud#1752